### PR TITLE
Fix compilation errors and warnings

### DIFF
--- a/Diplom/EA/Basic/abstract_opl.h
+++ b/Diplom/EA/Basic/abstract_opl.h
@@ -3,8 +3,8 @@
 
 
 #include "source.h"
-#import "EA/representative.h"
-#import "WModel/w_model.h"
+#include "EA/representative.h"
+#include "WModel/w_model.h"
 
 struct abstract_opl {
 

--- a/Diplom/EA/representative.h
+++ b/Diplom/EA/representative.h
@@ -1,7 +1,7 @@
 #ifndef DIPLOM_REPRESENTATIVE_H
 #define DIPLOM_REPRESENTATIVE_H
 
-#import "source.h"
+#include "source.h"
 
 
 struct representative {

--- a/Diplom/main.cpp
+++ b/Diplom/main.cpp
@@ -1,3 +1,7 @@
+#include <algorithm>
+
+using std::sort;
+
 #include "name_getter.h"
 #import "structures.h"
 

--- a/Diplom/main.cpp
+++ b/Diplom/main.cpp
@@ -3,7 +3,7 @@
 using std::sort;
 
 #include "name_getter.h"
-#import "structures.h"
+#include "structures.h"
 
 // ------------------------------------- Common -------------------------------------
 

--- a/Diplom/structures.h
+++ b/Diplom/structures.h
@@ -1,7 +1,7 @@
 #ifndef DIPLOM_STRUCTURES_H
 #define DIPLOM_STRUCTURES_H
 
-#import "source.h"
+#include "source.h"
 #include <WModel/w_model.h>
 
 // --- W-model structures ---


### PR DESCRIPTION
`main.cpp` uses `std::sort`, but this used to be in a non-portable way.

All `#import`s were replaced by `#include`, since the former is a deprecated GNU extension. As all included files were properly guarded, nothing got broken.
